### PR TITLE
fix: try-catch on api

### DIFF
--- a/src/data/delete-auth-logout.ts
+++ b/src/data/delete-auth-logout.ts
@@ -13,13 +13,19 @@ export const deleteAuthLogout = async () => {
 
     return { data };
   } catch (err) {
-    const status = (err as Response).status as Extract<
-      keyof paths['/auth/logout']['delete']['responses'],
-      ErrorStatus
-    >;
+    if (err instanceof Response) {
+      const status = err.status as Extract<
+        keyof paths['/auth/logout']['delete']['responses'],
+        ErrorStatus
+      >;
+
+      return {
+        status: AuthLogoutStatus[status] as keyof typeof AuthLogoutStatus,
+      };
+    }
 
     return {
-      status: AuthLogoutStatus[status] as keyof typeof AuthLogoutStatus,
+      status: 'UNKNOWN_ERROR' as const,
     };
   }
 };

--- a/src/data/delete-auth-logout.ts
+++ b/src/data/delete-auth-logout.ts
@@ -3,17 +3,23 @@ import type { ErrorStatus } from 'openapi-typescript-helpers';
 import { paths } from '@/@types/api-schema';
 import { api } from '@/features/core';
 
-export const deleteAuthLogout = async () => {
-  const { data, error, response } = await api.DELETE('/auth/logout');
+enum AuthLogoutStatus {
+  SERVER_ERROR = 500,
+}
 
-  if (error || !data) {
-    const status = response.status as Extract<
+export const deleteAuthLogout = async () => {
+  try {
+    const { data } = await api.DELETE('/auth/logout');
+
+    return { data };
+  } catch (err) {
+    const status = (err as Response).status as Extract<
       keyof paths['/auth/logout']['delete']['responses'],
       ErrorStatus
     >;
 
-    return { error, status };
+    return {
+      status: AuthLogoutStatus[status] as keyof typeof AuthLogoutStatus,
+    };
   }
-
-  return { data };
 };

--- a/src/data/get-client-public.ts
+++ b/src/data/get-client-public.ts
@@ -10,21 +10,20 @@ enum ClientPublicStatus {
 }
 
 export const getClientPublic = async (clientId: string) => {
-  const { data, error, response } = await api.GET('/client/{clientId}/public', {
-    params: { path: { clientId } },
-  });
+  try {
+    const { data } = await api.GET('/client/{clientId}/public', {
+      params: { path: { clientId } },
+    });
 
-  if (error || !data) {
-    const status = response.status as Extract<
+    return { data };
+  } catch (err) {
+    const status = (err as Response).status as Extract<
       keyof paths['/client/{clientId}/public']['get']['responses'],
       ErrorStatus
     >;
 
     return {
-      error,
       status: ClientPublicStatus[status] as keyof typeof ClientPublicStatus,
     };
   }
-
-  return { data };
 };

--- a/src/data/get-client-public.ts
+++ b/src/data/get-client-public.ts
@@ -17,13 +17,19 @@ export const getClientPublic = async (clientId: string) => {
 
     return { data };
   } catch (err) {
-    const status = (err as Response).status as Extract<
-      keyof paths['/client/{clientId}/public']['get']['responses'],
-      ErrorStatus
-    >;
+    if (err instanceof Response) {
+      const status = err.status as Extract<
+        keyof paths['/client/{clientId}/public']['get']['responses'],
+        ErrorStatus
+      >;
+
+      return {
+        status: ClientPublicStatus[status] as keyof typeof ClientPublicStatus,
+      };
+    }
 
     return {
-      status: ClientPublicStatus[status] as keyof typeof ClientPublicStatus,
+      status: 'UNKNOWN_ERROR' as const,
     };
   }
 };

--- a/src/data/get-user-consent.ts
+++ b/src/data/get-user-consent.ts
@@ -14,13 +14,19 @@ export const getUserConsent = async () => {
 
     return { data };
   } catch (err) {
-    const status = (err as Response).status as Extract<
-      keyof paths['/user/consent']['get']['responses'],
-      ErrorStatus
-    >;
+    if (err instanceof Response) {
+      const status = err.status as Extract<
+        keyof paths['/user/consent']['get']['responses'],
+        ErrorStatus
+      >;
+
+      return {
+        status: UserConsentStatus[status] as keyof typeof UserConsentStatus,
+      };
+    }
 
     return {
-      status: UserConsentStatus[status] as keyof typeof UserConsentStatus,
+      status: 'UNKNOWN_ERROR' as const,
     };
   }
 };

--- a/src/data/get-user-consent.ts
+++ b/src/data/get-user-consent.ts
@@ -9,19 +9,18 @@ enum UserConsentStatus {
 }
 
 export const getUserConsent = async () => {
-  const { data, error, response } = await api.GET('/user/consent');
+  try {
+    const { data } = await api.GET('/user/consent');
 
-  if (error || !data) {
-    const status = response.status as Extract<
+    return { data };
+  } catch (err) {
+    const status = (err as Response).status as Extract<
       keyof paths['/user/consent']['get']['responses'],
       ErrorStatus
     >;
 
     return {
-      error,
       status: UserConsentStatus[status] as keyof typeof UserConsentStatus,
     };
   }
-
-  return { data };
 };

--- a/src/data/get-user.ts
+++ b/src/data/get-user.ts
@@ -14,11 +14,19 @@ export const getUser = async () => {
 
     return { data };
   } catch (err) {
-    const status = (err as Response).status as Extract<
-      keyof paths['/user']['get']['responses'],
-      ErrorStatus
-    >;
+    if (err instanceof Response) {
+      const status = err.status as Extract<
+        keyof paths['/user']['get']['responses'],
+        ErrorStatus
+      >;
 
-    return { status: UserStatus[status] as keyof typeof UserStatus };
+      return {
+        status: UserStatus[status] as keyof typeof UserStatus,
+      };
+    }
+
+    return {
+      status: 'UNKNOWN_ERROR' as const,
+    };
   }
 };

--- a/src/data/get-user.ts
+++ b/src/data/get-user.ts
@@ -9,16 +9,16 @@ enum UserStatus {
 }
 
 export const getUser = async () => {
-  const { data, error, response } = await api.GET('/user');
+  try {
+    const { data } = await api.GET('/user');
 
-  if (error || !data) {
-    const status = response.status as Extract<
+    return { data };
+  } catch (err) {
+    const status = (err as Response).status as Extract<
       keyof paths['/user']['get']['responses'],
       ErrorStatus
     >;
 
-    return { error, status: UserStatus[status] as keyof typeof UserStatus };
+    return { status: UserStatus[status] as keyof typeof UserStatus };
   }
-
-  return { data };
 };

--- a/src/data/post-auth-login.ts
+++ b/src/data/post-auth-login.ts
@@ -11,21 +11,20 @@ enum AuthLoginStatus {
 export const postAuthLogin = async (
   requestBody: paths['/auth/login']['post']['requestBody']['content']['application/json'],
 ) => {
-  const { data, error, response } = await api.POST('/auth/login', {
-    body: requestBody,
-  });
+  try {
+    const { data } = await api.POST('/auth/login', {
+      body: requestBody,
+    });
 
-  if (error || !data) {
-    const status = response.status as Extract<
+    return { data };
+  } catch (err) {
+    const status = (err as Response).status as Extract<
       keyof paths['/auth/login']['post']['responses'],
       ErrorStatus
     >;
 
     return {
-      error,
       status: AuthLoginStatus[status] as keyof typeof AuthLoginStatus,
     };
   }
-
-  return { data };
 };

--- a/src/data/post-auth-login.ts
+++ b/src/data/post-auth-login.ts
@@ -18,13 +18,19 @@ export const postAuthLogin = async (
 
     return { data };
   } catch (err) {
-    const status = (err as Response).status as Extract<
-      keyof paths['/auth/login']['post']['responses'],
-      ErrorStatus
-    >;
+    if (err instanceof Response) {
+      const status = err.status as Extract<
+        keyof paths['/auth/login']['post']['responses'],
+        ErrorStatus
+      >;
+
+      return {
+        status: AuthLoginStatus[status] as keyof typeof AuthLoginStatus,
+      };
+    }
 
     return {
-      status: AuthLoginStatus[status] as keyof typeof AuthLoginStatus,
+      status: 'UNKNOWN_ERROR' as const,
     };
   }
 };

--- a/src/data/post-auth-refresh.ts
+++ b/src/data/post-auth-refresh.ts
@@ -15,13 +15,19 @@ export const postAuthRefresh = async () => {
 
     return { data };
   } catch (err) {
-    const status = (err as Response).status as Extract<
-      keyof paths['/auth/refresh']['post']['responses'],
-      ErrorStatus
-    >;
+    if (err instanceof Response) {
+      const status = err.status as Extract<
+        keyof paths['/auth/refresh']['post']['responses'],
+        ErrorStatus
+      >;
+
+      return {
+        status: AuthRefreshStatus[status] as keyof typeof AuthRefreshStatus,
+      };
+    }
 
     return {
-      status: AuthRefreshStatus[status] as keyof typeof AuthRefreshStatus,
+      status: 'UNKNOWN_ERROR' as const,
     };
   }
 };

--- a/src/data/post-auth-refresh.ts
+++ b/src/data/post-auth-refresh.ts
@@ -8,21 +8,20 @@ enum AuthRefreshStatus {
 }
 
 export const postAuthRefresh = async () => {
-  const { data, error, response } = await api.POST('/auth/refresh', {
-    retry: true,
-  });
+  try {
+    const { data } = await api.POST('/auth/refresh', {
+      retry: true,
+    });
 
-  if (error || !data) {
-    const status = response.status as Extract<
-      keyof paths['/auth/login']['post']['responses'],
+    return { data };
+  } catch (err) {
+    const status = (err as Response).status as Extract<
+      keyof paths['/auth/refresh']['post']['responses'],
       ErrorStatus
     >;
 
     return {
-      error,
       status: AuthRefreshStatus[status] as keyof typeof AuthRefreshStatus,
     };
   }
-
-  return { data };
 };

--- a/src/data/post-oauth-consent.ts
+++ b/src/data/post-oauth-consent.ts
@@ -3,21 +3,27 @@ import type { ErrorStatus } from 'openapi-typescript-helpers';
 import { paths } from '@/@types/api-schema';
 import { api } from '@/features/core';
 
+enum OauthConsentStatus {
+  SERVER_ERROR = 500,
+}
+
 export const postOauthConsent = async (
   requestBody: paths['/oauth/consent']['post']['requestBody']['content']['application/json'],
 ) => {
-  const { data, error, response } = await api.POST('/oauth/consent', {
-    body: requestBody,
-  });
+  try {
+    const { data } = await api.POST('/oauth/consent', {
+      body: requestBody,
+    });
 
-  if (error || !data) {
-    const status = response.status as Extract<
+    return { data };
+  } catch (err) {
+    const status = (err as Response).status as Extract<
       keyof paths['/oauth/consent']['post']['responses'],
       ErrorStatus
     >;
 
-    return { error, status };
+    return {
+      status: OauthConsentStatus[status] as keyof typeof OauthConsentStatus,
+    };
   }
-
-  return { data };
 };

--- a/src/data/post-oauth-consent.ts
+++ b/src/data/post-oauth-consent.ts
@@ -17,13 +17,19 @@ export const postOauthConsent = async (
 
     return { data };
   } catch (err) {
-    const status = (err as Response).status as Extract<
-      keyof paths['/oauth/consent']['post']['responses'],
-      ErrorStatus
-    >;
+    if (err instanceof Response) {
+      const status = err.status as Extract<
+        keyof paths['/oauth/consent']['post']['responses'],
+        ErrorStatus
+      >;
+
+      return {
+        status: OauthConsentStatus[status] as keyof typeof OauthConsentStatus,
+      };
+    }
 
     return {
-      status: OauthConsentStatus[status] as keyof typeof OauthConsentStatus,
+      status: 'UNKNOWN_ERROR' as const,
     };
   }
 };

--- a/src/data/post-user.ts
+++ b/src/data/post-user.ts
@@ -31,13 +31,19 @@ export const postUser = async (
 
     return { data };
   } catch (err) {
-    const status = (err as Response).status as Extract<
-      keyof paths['/user']['post']['responses'],
-      ErrorStatus
-    >;
+    if (err instanceof Response) {
+      const status = err.status as Extract<
+        keyof paths['/user']['post']['responses'],
+        ErrorStatus
+      >;
+
+      return {
+        status: UserStatus[status] as keyof typeof UserStatus,
+      };
+    }
 
     return {
-      status: UserStatus[status] as keyof typeof UserStatus,
+      status: 'UNKNOWN_ERROR' as const,
     };
   }
 };

--- a/src/data/post-user.ts
+++ b/src/data/post-user.ts
@@ -24,18 +24,20 @@ export const postUser = async (
     phoneNumber: parsedPhoneNumber.number,
   };
 
-  const { data, error, response } = await api.POST('/user', {
-    body: modifiedRequestBody,
-  });
+  try {
+    const { data } = await api.POST('/user', {
+      body: modifiedRequestBody,
+    });
 
-  if (error || !data) {
-    const status = response.status as Extract<
+    return { data };
+  } catch (err) {
+    const status = (err as Response).status as Extract<
       keyof paths['/user']['post']['responses'],
       ErrorStatus
     >;
 
-    return { error, status: UserStatus[status] as keyof typeof UserStatus };
+    return {
+      status: UserStatus[status] as keyof typeof UserStatus,
+    };
   }
-
-  return { data };
 };

--- a/src/data/post-verify-email.ts
+++ b/src/data/post-verify-email.ts
@@ -17,13 +17,19 @@ export const postVerifyEmail = async (
 
     return { data };
   } catch (err) {
-    const status = (err as Response).status as Extract<
-      keyof paths['/verify/email']['post']['responses'],
-      ErrorStatus
-    >;
+    if (err instanceof Response) {
+      const status = err.status as Extract<
+        keyof paths['/verify/email']['post']['responses'],
+        ErrorStatus
+      >;
+
+      return {
+        status: VerifyEmailStatus[status] as keyof typeof VerifyEmailStatus,
+      };
+    }
 
     return {
-      status: VerifyEmailStatus[status] as keyof typeof VerifyEmailStatus,
+      status: 'UNKNOWN_ERROR' as const,
     };
   }
 };

--- a/src/data/post-verify-email.ts
+++ b/src/data/post-verify-email.ts
@@ -10,21 +10,20 @@ enum VerifyEmailStatus {
 export const postVerifyEmail = async (
   requestBody: paths['/verify/email']['post']['requestBody']['content']['application/json'],
 ) => {
-  const { data, error, response } = await api.POST('/verify/email', {
-    body: requestBody,
-  });
+  try {
+    const { data } = await api.POST('/verify/email', {
+      body: requestBody,
+    });
 
-  if (error || !data) {
-    const status = response.status as Extract<
+    return { data };
+  } catch (err) {
+    const status = (err as Response).status as Extract<
       keyof paths['/verify/email']['post']['responses'],
       ErrorStatus
     >;
 
     return {
-      error,
       status: VerifyEmailStatus[status] as keyof typeof VerifyEmailStatus,
     };
   }
-
-  return { data };
 };

--- a/src/data/post-verify.ts
+++ b/src/data/post-verify.ts
@@ -18,13 +18,19 @@ export const postVerify = async (
 
     return { data };
   } catch (err) {
-    const status = (err as Response).status as Extract<
-      keyof paths['/verify']['post']['responses'],
-      ErrorStatus
-    >;
+    if (err instanceof Response) {
+      const status = err.status as Extract<
+        keyof paths['/verify']['post']['responses'],
+        ErrorStatus
+      >;
+
+      return {
+        status: VerifyStatus[status] as keyof typeof VerifyStatus,
+      };
+    }
 
     return {
-      status: VerifyStatus[status] as keyof typeof VerifyStatus,
+      status: 'UNKNOWN_ERROR' as const,
     };
   }
 };

--- a/src/data/post-verify.ts
+++ b/src/data/post-verify.ts
@@ -11,18 +11,20 @@ enum VerifyStatus {
 export const postVerify = async (
   requestBody: paths['/verify']['post']['requestBody']['content']['application/json'],
 ) => {
-  const { data, error, response } = await api.POST('/verify', {
-    body: requestBody,
-  });
+  try {
+    const { data } = await api.POST('/verify', {
+      body: requestBody,
+    });
 
-  if (error || !data) {
-    const status = response.status as Extract<
+    return { data };
+  } catch (err) {
+    const status = (err as Response).status as Extract<
       keyof paths['/verify']['post']['responses'],
       ErrorStatus
     >;
 
-    return { error, status: VerifyStatus[status] as keyof typeof VerifyStatus };
+    return {
+      status: VerifyStatus[status] as keyof typeof VerifyStatus,
+    };
   }
-
-  return { data };
 };

--- a/src/features/auth/hooks/steps/use-code-form.ts
+++ b/src/features/auth/hooks/steps/use-code-form.ts
@@ -49,6 +49,9 @@ export const useCodeForm = ({
         case 'SERVER_ERROR':
           console.error('Server error');
           break;
+        case 'UNKNOWN_ERROR':
+          console.error('Unknown error');
+          break;
       }
 
       return;

--- a/src/features/auth/hooks/steps/use-code-form.ts
+++ b/src/features/auth/hooks/steps/use-code-form.ts
@@ -39,7 +39,7 @@ export const useCodeForm = ({
       hint: 'email',
     });
 
-    if (!data && status) {
+    if (!data || status) {
       switch (status) {
         case 'INVALID_CERTIFICATE':
           form.setError('code', {

--- a/src/features/auth/hooks/steps/use-email-form.ts
+++ b/src/features/auth/hooks/steps/use-email-form.ts
@@ -38,6 +38,9 @@ export const useEmailForm = ({
         case 'SERVER_ERROR':
           console.error('Server error');
           break;
+        case 'UNKNOWN_ERROR':
+          console.error('Unknown error');
+          break;
       }
 
       return;

--- a/src/features/auth/hooks/steps/use-info-form.ts
+++ b/src/features/auth/hooks/steps/use-info-form.ts
@@ -63,6 +63,9 @@ export const useInfoForm = ({
         case 'SERVER_ERROR':
           console.error('Server error');
           break;
+        case 'UNKNOWN_ERROR':
+          console.error('Unknown error');
+          break;
       }
 
       return;

--- a/src/features/auth/hooks/use-auth.ts
+++ b/src/features/auth/hooks/use-auth.ts
@@ -28,7 +28,21 @@ export const useAuth = () => {
   }, [refetch, token]);
 
   const signOut = useCallback(async () => {
-    await deleteAuthLogout();
+    const { status } = await deleteAuthLogout();
+
+    if (status) {
+      switch (status) {
+        case 'SERVER_ERROR':
+          console.error('Server error');
+          break;
+        case 'UNKNOWN_ERROR':
+          console.error('Unknown error');
+          break;
+      }
+
+      return;
+    }
+
     saveToken(null);
   }, [saveToken]);
 

--- a/src/features/auth/hooks/use-login-form.ts
+++ b/src/features/auth/hooks/use-login-form.ts
@@ -31,7 +31,7 @@ export const useLoginForm = () => {
   const onSubmit = form.handleSubmit(async (formData) => {
     const { data, status } = await postAuthLogin(formData);
 
-    if (!data && status) {
+    if (!data || status) {
       switch (status) {
         case 'LOGIN_FAILURE':
           form.resetField('password', { keepError: true });

--- a/src/features/auth/hooks/use-login-form.ts
+++ b/src/features/auth/hooks/use-login-form.ts
@@ -40,6 +40,9 @@ export const useLoginForm = () => {
         case 'SERVER_ERROR':
           console.error('Server error');
           break;
+        case 'UNKNOWN_ERROR':
+          console.error('Unknown error');
+          break;
       }
 
       return;

--- a/src/features/auth/hooks/use-register-form.ts
+++ b/src/features/auth/hooks/use-register-form.ts
@@ -60,6 +60,9 @@ export const useRegisterForm = () => {
         case 'SERVER_ERROR':
           console.error('Server error');
           break;
+        case 'UNKNOWN_ERROR':
+          console.error('Unknown error');
+          break;
       }
     }
   };
@@ -80,6 +83,9 @@ export const useRegisterForm = () => {
           break;
         case 'SERVER_ERROR':
           console.error('Server error');
+          break;
+        case 'UNKNOWN_ERROR':
+          console.error('Unknown error');
           break;
       }
 
@@ -107,6 +113,9 @@ export const useRegisterForm = () => {
           break;
         case 'SERVER_ERROR':
           console.error('Server error');
+          break;
+        case 'UNKNOWN_ERROR':
+          console.error('Unknown error');
           break;
       }
     }

--- a/src/features/auth/hooks/use-register-form.ts
+++ b/src/features/auth/hooks/use-register-form.ts
@@ -71,7 +71,7 @@ export const useRegisterForm = () => {
       hint: 'email',
     });
 
-    if (!data && status) {
+    if (!data || status) {
       switch (status) {
         case 'INVALID_CERTIFICATE':
           form.setError('code', {

--- a/src/features/oauth/hooks/use-authorize-form.ts
+++ b/src/features/oauth/hooks/use-authorize-form.ts
@@ -31,10 +31,23 @@ export const useAuthorizeForm = ({
       .filter(([, value]) => value === true)
       .map(([key]) => key as ClientScopeType);
 
-    await postOauthConsent({
+    const { status } = await postOauthConsent({
       client_id: clientId,
       scope: scopes.join(' '),
     });
+
+    if (status) {
+      switch (status) {
+        case 'SERVER_ERROR':
+          console.error('Server error');
+          break;
+        case 'UNKNOWN_ERROR':
+          console.error('Unknown error');
+          break;
+      }
+
+      return;
+    }
 
     onDone(scopes);
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **리팩터링**
  - 여러 인증 및 사용자 관련 API 함수에서 에러 처리 방식을 try-catch 블록으로 단순화하여, 에러 발생 시 상태(status)만 반환하도록 변경되었습니다.
  - 성공 시 데이터만 반환하고, 실패 시 상태만 반환하여 응답 구조가 일관되게 개선되었습니다.

- **버그 수정**
  - 인증 및 회원가입/로그인 폼에서 API 응답 처리 조건이 `if (!data && status)`에서 `if (!data || status)`로 변경되어, 더 넓은 오류 상황을 정확하게 감지할 수 있게 되었습니다.

- **기능 개선**
  - 인증, 사용자 정보, OAuth 동의 등 주요 API 호출 후 반환되는 상태값에 `UNKNOWN_ERROR` 케이스가 추가되어, 알 수 없는 오류 상황에 대한 로그가 콘솔에 출력됩니다.
  - 로그아웃, OAuth 동의, 회원가입 등 주요 기능에서 오류 상태를 명확히 처리하여, 오류 발생 시 적절한 메시지 출력 및 후속 동작 차단이 이루어집니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->