### PR TITLE
fix: update link search exclude step-related parameter

### DIFF
--- a/src/features/auth/frames/steps/complete-step.tsx
+++ b/src/features/auth/frames/steps/complete-step.tsx
@@ -20,7 +20,14 @@ export function CompleteStep({
       stepTitle={t('register.steps.complete.title')}
       onUndoClick={onUndo}
       button={
-        <Link to="/auth/login" search={(prev) => ({ ...prev })}>
+        <Link
+          to="/auth/login"
+          search={(prev) =>
+            Object.fromEntries(
+              Object.entries(prev).filter(([key]) => !key.endsWith('-step')),
+            )
+          }
+        >
           <Button variant="primary" className="w-full">
             {t('register.steps.complete.button')}
           </Button>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 로그인 페이지로 이동할 때 URL에서 단계와 관련된 쿼리 파라미터가 제거되어 보다 깔끔한 주소로 접속할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->