### PR TITLE
feat: cancel redirect

### DIFF
--- a/src/features/oauth/frames/authorize-frame.tsx
+++ b/src/features/oauth/frames/authorize-frame.tsx
@@ -41,7 +41,7 @@ function Inner({
   client: components['schemas']['ClientPublicResDto'];
 }) {
   const { t } = useTranslation();
-  const { form, onSubmit } = useAuthorize({ client });
+  const { form, onSubmit, onCancel } = useAuthorize({ client });
 
   return (
     <FormProvider {...form}>
@@ -57,10 +57,7 @@ function Inner({
                 variant="secondary"
                 className="w-full"
                 type="button"
-                onClick={() => {
-                  // TODO: 에러 메시지 담아서 redirect
-                  window.close();
-                }}
+                onClick={onCancel}
               >
                 {t('authorize.buttons.cancel')}
               </Button>

--- a/src/features/oauth/hooks/use-authorize.ts
+++ b/src/features/oauth/hooks/use-authorize.ts
@@ -38,6 +38,13 @@ export const useAuthorize = ({
     [url, state],
   );
 
+  const onCancel = useCallback(() => {
+    redirect({
+      error: 'access_denied',
+      error_description: 'user_cancelled',
+    });
+  }, [redirect]);
+
   const authorize = useCallback(
     (agreed: ClientScopeType[]) => {
       const query = new URLSearchParams(search);
@@ -108,8 +115,11 @@ export const useAuthorize = ({
     user,
   ]);
 
-  return useAuthorizeForm({
-    clientId: client.clientId,
-    onDone: authorize,
-  });
+  return {
+    ...useAuthorizeForm({
+      clientId: client.clientId,
+      onDone: authorize,
+    }),
+    onCancel,
+  };
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - OAuth 인증 화면에서 사용자가 인증을 취소할 수 있는 버튼이 추가되어, 취소 시 보다 명확한 안내와 함께 인증이 중단됩니다.

- **버그 수정**
  - 인증 취소 시 단순 창 닫기 대신, 사용자 취소에 대한 오류 메시지와 함께 적절한 리디렉션이 이루어집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->