### PR TITLE
refactor: change button disabled color

### DIFF
--- a/src/features/core/components/button.tsx
+++ b/src/features/core/components/button.tsx
@@ -17,12 +17,12 @@ const buttonStyle = cva(
     variants: {
       variant: {
         default:
-          'rounded-lg border border-neutral-200 bg-neutral-50 px-5 py-3 text-black active:bg-neutral-100 disabled:border-neutral-300 disabled:bg-neutral-200 disabled:text-neutral-500',
+          'rounded-lg border border-neutral-200 bg-neutral-50 px-5 py-3 text-black active:bg-neutral-100 disabled:border-neutral-300 disabled:bg-neutral-200 disabled:text-neutral-300',
         primary:
-          'bg-primary-600 active:bg-primary-700 rounded-lg px-5 py-3 text-white disabled:bg-neutral-600',
+          'bg-primary-600 active:bg-primary-700 rounded-lg px-5 py-3 text-white disabled:bg-neutral-200',
         secondary:
-          'text-primary-600 border-primary-600 active:bg-primary-50 rounded-lg border bg-white px-5 py-3 disabled:border-neutral-600 disabled:bg-neutral-100 disabled:text-neutral-600',
-        text: 'text-primary-600 active:text-primary-700 px-5 py-3 disabled:text-neutral-600',
+          'text-primary-600 border-primary-600 active:bg-primary-50 rounded-lg border bg-white px-5 py-3 disabled:border-neutral-200 disabled:bg-neutral-50 disabled:text-neutral-200',
+        text: 'text-primary-600 active:text-primary-700 px-5 py-3 disabled:text-neutral-200',
         link: 'text-body-1 text-neutral-400 underline active:text-neutral-600 disabled:cursor-default disabled:text-neutral-200',
       },
       loading: {


### PR DESCRIPTION
<img width="875" alt="image" src="https://github.com/user-attachments/assets/59c2ce75-44ef-49fd-b4c2-70c958b46449" />

<img width="350" alt="image" src="https://github.com/user-attachments/assets/bde04e77-ce61-49af-9e4e-48d56fed2060" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 버튼의 비활성화(disabled) 상태에서 텍스트, 배경, 테두리 색상이 더 밝은 색상으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->