### PR TITLE
fix: load previously agreed scopes

### DIFF
--- a/src/features/oauth/components/authorize-form.tsx
+++ b/src/features/oauth/components/authorize-form.tsx
@@ -91,54 +91,55 @@ export function AuthorizeForm({
         <div className="font-bold">{t('authorize.checkboxes.all_agree')}</div>
       </Checkbox>
       <div className="h-2.5" />
-      <div className="rounded-lg border border-neutral-200 px-5 py-4">
+      <div className="flex flex-col gap-2.5 rounded-lg border border-neutral-200 px-5 py-4">
         {requiredScopes.length > 0 && (
-          <div className="text-body-2 mb-1 text-neutral-800">
-            {t('authorize.labels.required')}
+          <div className="flex flex-col gap-1">
+            <div className="text-body-2 text-neutral-800">
+              {t('authorize.labels.required')}
+            </div>
+            <div className="flex flex-col gap-1 pl-1">
+              {requiredScopes.map((scope) => (
+                <Controller
+                  key={scope}
+                  name={`scopes.${scope}`}
+                  control={control}
+                  render={({ field }) => (
+                    <Checkbox
+                      checked={field.value ?? false}
+                      onChange={field.onChange}
+                    >
+                      {t(`authorize.checkboxes.${scope}`)}
+                    </Checkbox>
+                  )}
+                />
+              ))}
+            </div>
           </div>
-        )}
-        <div className="flex flex-col gap-1 pl-1">
-          {requiredScopes.map((scope) => (
-            <Controller
-              key={scope}
-              name={`scopes.${scope}`}
-              control={control}
-              render={({ field }) => (
-                <Checkbox
-                  checked={field.value ?? false}
-                  onChange={field.onChange}
-                >
-                  {t(`authorize.checkboxes.${scope}`)}
-                </Checkbox>
-              )}
-            />
-          ))}
-        </div>
-        {requiredScopes.length > 0 && optionalScopes.length > 0 && (
-          <div className="h-2.5" />
         )}
         {optionalScopes.length > 0 && (
-          <div className="text-body-2 mb-1 text-neutral-800">
-            {t('authorize.labels.optional')}
+          <div className="flex flex-col gap-1">
+            <div className="text-body-2 text-neutral-800">
+              {t('authorize.labels.optional')}
+            </div>
+            <div className="flex flex-col gap-1 pl-1">
+              {optionalScopes.map((scope) => (
+                <Controller
+                  key={scope}
+                  name={`scopes.${scope}`}
+                  control={control}
+                  render={({ field }) => (
+                    <Checkbox
+                      checked={field.value ?? false}
+                      onChange={field.onChange}
+                    >
+                      {t(`authorize.checkboxes.${scope}`)}
+                    </Checkbox>
+                  )}
+                />
+              ))}
+            </div>
           </div>
         )}
-        <div className="flex flex-col gap-1 pl-1">
-          {optionalScopes.map((scope) => (
-            <Controller
-              key={scope}
-              name={`scopes.${scope}`}
-              control={control}
-              render={({ field }) => (
-                <Checkbox
-                  checked={field.value ?? false}
-                  onChange={field.onChange}
-                >
-                  {t(`authorize.checkboxes.${scope}`)}
-                </Checkbox>
-              )}
-            />
-          ))}
-        </div>
       </div>
     </div>
   );

--- a/src/features/oauth/components/authorize-form.tsx
+++ b/src/features/oauth/components/authorize-form.tsx
@@ -16,14 +16,19 @@ export function AuthorizeForm({
   const { control, setValue, setError, clearErrors } =
     useFormContext<ConsentFormSchema>();
   const { t } = useTranslation();
-  const { clientScopes } = useLoaderData({
+  const { clientScopes, consents } = useLoaderData({
     from: '/_auth-required/authorize',
   });
+
+  const consent = consents?.data?.list.find(
+    (c) => c.clientUuid === client.clientId,
+  );
 
   const requiredScopes = useMemo(
     () => clientScopes.filter((v) => client.scopes.includes(v)),
     [clientScopes, client.scopes],
   );
+
   const optionalScopes = useMemo(
     () => clientScopes.filter((v) => client.optionalScopes.includes(v)),
     [clientScopes, client.optionalScopes],
@@ -73,10 +78,10 @@ export function AuthorizeForm({
 
   useEffect(() => {
     requiredScopes.forEach((scope) => {
-      setValue(`scopes.${scope}`, false);
+      setValue(`scopes.${scope}`, consent?.scopes.includes(scope) ?? false);
     });
     optionalScopes.forEach((scope) => {
-      setValue(`scopes.${scope}`, false);
+      setValue(`scopes.${scope}`, consent?.scopes.includes(scope) ?? false);
     });
   }, [requiredScopes, optionalScopes, setValue]);
 
@@ -87,9 +92,11 @@ export function AuthorizeForm({
       </Checkbox>
       <div className="h-2.5" />
       <div className="rounded-lg border border-neutral-200 px-5 py-4">
-        <div className="text-body-2 mb-1 text-neutral-800">
-          {t('authorize.labels.required')}
-        </div>
+        {requiredScopes.length > 0 && (
+          <div className="text-body-2 mb-1 text-neutral-800">
+            {t('authorize.labels.required')}
+          </div>
+        )}
         <div className="flex flex-col gap-1 pl-1">
           {requiredScopes.map((scope) => (
             <Controller
@@ -107,10 +114,14 @@ export function AuthorizeForm({
             />
           ))}
         </div>
-        <div className="h-2.5" />
-        <div className="text-body-2 mb-1 text-neutral-800">
-          {t('authorize.labels.optional')}
-        </div>
+        {requiredScopes.length > 0 && optionalScopes.length > 0 && (
+          <div className="h-2.5" />
+        )}
+        {optionalScopes.length > 0 && (
+          <div className="text-body-2 mb-1 text-neutral-800">
+            {t('authorize.labels.optional')}
+          </div>
+        )}
         <div className="flex flex-col gap-1 pl-1">
           {optionalScopes.map((scope) => (
             <Controller

--- a/src/features/oauth/components/authorize-form.tsx
+++ b/src/features/oauth/components/authorize-form.tsx
@@ -83,7 +83,7 @@ export function AuthorizeForm({
     optionalScopes.forEach((scope) => {
       setValue(`scopes.${scope}`, consent?.scopes.includes(scope) ?? false);
     });
-  }, [requiredScopes, optionalScopes, setValue]);
+  }, [requiredScopes, optionalScopes, setValue, consent]);
 
   return (
     <div className="flex flex-col">

--- a/src/features/oauth/frames/authorize-frame.tsx
+++ b/src/features/oauth/frames/authorize-frame.tsx
@@ -7,7 +7,7 @@ import { useAuthorize } from '../hooks/use-authorize';
 import { useClient } from '../hooks/use-client';
 
 import { components } from '@/@types/api-schema';
-import { Button, FunnelLayout } from '@/features/core';
+import { Avatar, Button, FunnelLayout, uniqueKey } from '@/features/core';
 
 export function AuthorizeFrame() {
   const { clientId } = useLoaderData({
@@ -49,7 +49,18 @@ function Inner({
         <FunnelLayout
           hideUndo
           loading={form.formState.isSubmitting}
-          stepTitle={t('authorize.title', { client: client.name })}
+          stepTitle={
+            <div className="flex flex-col gap-5">
+              <Avatar
+                name={client.name}
+                img={client.picture ?? undefined}
+                size={13}
+                seed={uniqueKey(client.clientId)}
+                className="rounded-lg border border-neutral-200"
+              />
+              {t('authorize.title', { client: client.name })}
+            </div>
+          }
           description={t('authorize.description', { client: client.name })}
           button={
             <div className="flex gap-2.5">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 기존 동의 내역을 반영하여 권한(스코프) 체크박스의 초기 선택 상태가 자동으로 설정됩니다.
  - 필수 및 선택 권한이 각각 존재할 때만 해당 라벨과 구분선이 표시되어, 동의 화면의 가독성이 향상되었습니다.
  - 필수 권한과 선택 권한에 대해 각각 전체 동의 토글 기능이 추가되어, 사용자가 한 번에 모든 권한을 선택하거나 해제할 수 있습니다.
  - 동의 화면 상단에 클라이언트의 아바타와 이름이 함께 표시되어, 시각적 식별이 용이해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->