### PR TITLE
fix: doubled profile edit overlay

### DIFF
--- a/src/features/profile/components/profile-edit-overlay.tsx
+++ b/src/features/profile/components/profile-edit-overlay.tsx
@@ -46,10 +46,7 @@ export function ProfileEditOverlay({
     <Modal isOpen={isOpen} close={handleClose} className="min-w-100">
       <Modal.Header>{t('profile_change.title')}</Modal.Header>
       <Modal.Body className="flex justify-center">
-        <div
-          className="relative w-fit cursor-pointer"
-          onClick={() => fileInputRef.current?.click()}
-        >
+        <div className="relative w-fit cursor-pointer">
           <Avatar
             name={user.name}
             img={previewFile ?? undefined}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 아바타 이미지를 클릭할 때만 파일 선택 창이 열리도록 클릭 가능한 영역이 축소되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->