### PR TITLE
fix: view rendered before signout when prompt=login for authorization

### DIFF
--- a/src/features/oauth/frames/authorize-frame.tsx
+++ b/src/features/oauth/frames/authorize-frame.tsx
@@ -5,15 +5,25 @@ import { Trans, useTranslation } from 'react-i18next';
 import { AuthorizeForm } from '../components/authorize-form';
 import { useAuthorize } from '../hooks/use-authorize';
 import { useClient } from '../hooks/use-client';
+import { useRecentLogin } from '../hooks/use-recent-login';
 
 import { components } from '@/@types/api-schema';
 import { Avatar, Button, FunnelLayout, uniqueKey } from '@/features/core';
+import { useAuth } from '@/features/auth';
 
 export function AuthorizeFrame() {
-  const { clientId } = useLoaderData({
+  const { clientId, prompt } = useLoaderData({
     from: '/_auth-required/authorize',
   });
   const { client } = useClient(clientId);
+
+  const { recentLogin } = useRecentLogin();
+  const { signOut } = useAuth();
+
+  if (prompt === 'login' && !recentLogin) {
+    signOut();
+    return null;
+  }
 
   // TODO: Error Boundary + Suspense
   if (client === undefined) {

--- a/src/features/oauth/hooks/use-authorize.ts
+++ b/src/features/oauth/hooks/use-authorize.ts
@@ -88,11 +88,6 @@ export const useAuthorize = ({
       return authorize(consentedScopes);
     }
 
-    if (prompt === 'login') {
-      if (!recentLogin) return void signOut();
-      return; // show consent screen
-    }
-
     if (prompt === 'consent') return; // show consent screen
 
     if (consented) {

--- a/src/features/profile/components/profile-edit-overlay.tsx
+++ b/src/features/profile/components/profile-edit-overlay.tsx
@@ -31,8 +31,9 @@ export function ProfileEditOverlay({
   const fileInputRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!user) toast.error(t('toast.invalid_user'));
-    else setPreviewImage(user.picture ?? null);
+    if (!user) {
+      if (isOpen) toast.error(t('toast.invalid_user'));
+    } else setPreviewImage(user.picture ?? null);
   }, [user]);
 
   const handleClose = () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 프로필 편집 오버레이에서 오버레이가 열려 있을 때만 사용자 정보 오류 알림이 표시되도록 개선되었습니다.
* **기능 개선**
  * 인증 프레임에서 'login' 프롬프트와 최근 로그인 상태에 따라 자동 로그아웃 처리가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->