### PR TITLE
fix: mess history

### DIFF
--- a/src/features/auth/frames/register-frame.tsx
+++ b/src/features/auth/frames/register-frame.tsx
@@ -56,14 +56,14 @@ export function RegisterFrame() {
       code={({ history, context }) => (
         <CodeStep
           context={context}
-          onNext={(data) => history.replace('password', data)}
+          onNext={(data) => history.push('password', data)}
           onUndo={undoWarning}
         />
       )}
       password={({ history, context }) => (
         <PasswordStep
           context={context}
-          onNext={(data) => history.replace('info', data)}
+          onNext={(data) => history.push('info', data)}
           onUndo={undoWarning}
         />
       )}
@@ -78,8 +78,8 @@ export function RegisterFrame() {
         <CompleteStep
           context={context}
           onNext={async () => {
-            funnel.history.cleanup();
             await navigate({ to: '/auth/login', replace: true });
+            funnel.history.cleanup();
           }}
         />
       )}

--- a/src/features/auth/frames/register-frame.tsx
+++ b/src/features/auth/frames/register-frame.tsx
@@ -79,7 +79,7 @@ export function RegisterFrame() {
           context={context}
           onNext={async () => {
             funnel.history.cleanup();
-            await navigate({ to: '/auth/login' });
+            await navigate({ to: '/auth/login', replace: true });
           }}
         />
       )}

--- a/src/features/auth/frames/register-frame.tsx
+++ b/src/features/auth/frames/register-frame.tsx
@@ -28,7 +28,7 @@ export type RegisterSteps = {
 };
 
 export function RegisterFrame() {
-  const navigate = useNavigate({ from: '/auth/register' });
+  const navigate = useNavigate();
   const funnel = useFunnel<RegisterSteps>({
     id: 'register',
     initial: {
@@ -78,8 +78,13 @@ export function RegisterFrame() {
         <CompleteStep
           context={context}
           onNext={async () => {
-            await navigate({ to: '/auth/login', replace: true });
-            funnel.history.cleanup();
+            await funnel.history.cleanup();
+            await navigate({
+              to: '/auth/login',
+              replace: true,
+              viewTransition: { types: ['reload'] },
+              search: (prev) => ({ ...prev }),
+            });
           }}
         />
       )}

--- a/src/features/auth/frames/register-frame.tsx
+++ b/src/features/auth/frames/register-frame.tsx
@@ -50,20 +50,20 @@ export function RegisterFrame() {
       email={({ history, context }) => (
         <EmailStep
           context={context}
-          onNext={(data) => history.push('code', data)}
+          onNext={(data) => history.replace('code', data)}
         />
       )}
       code={({ history, context }) => (
         <CodeStep
           context={context}
-          onNext={(data) => history.push('password', data)}
+          onNext={(data) => history.replace('password', data)}
           onUndo={undoWarning}
         />
       )}
       password={({ history, context }) => (
         <PasswordStep
           context={context}
-          onNext={(data) => history.push('info', data)}
+          onNext={(data) => history.replace('info', data)}
           onUndo={undoWarning}
         />
       )}

--- a/src/features/auth/hooks/use-auth.ts
+++ b/src/features/auth/hooks/use-auth.ts
@@ -30,24 +30,27 @@ export const useAuth = () => {
     }
   }, [refetch, token]);
 
-  const signOut = useCallback(async () => {
-    const { status } = await deleteAuthLogout();
+  const signOut = useCallback(
+    async (shouldRedirect: boolean = true) => {
+      const { status } = await deleteAuthLogout();
 
-    if (status) {
-      switch (status) {
-        case 'SERVER_ERROR':
-          toast.error(t('toast.server_error'));
-          break;
-        case 'UNKNOWN_ERROR':
-          toast.error(t('toast.unknown_error'));
-          break;
+      if (status) {
+        switch (status) {
+          case 'SERVER_ERROR':
+            toast.error(t('toast.server_error'));
+            break;
+          case 'UNKNOWN_ERROR':
+            toast.error(t('toast.unknown_error'));
+            break;
+        }
+
+        return;
       }
 
-      return;
-    }
-
-    saveToken(null);
-  }, [saveToken, t]);
+      saveToken(shouldRedirect ? null : undefined);
+    },
+    [saveToken, t],
+  );
 
   return { user, refetch, signOut };
 };

--- a/src/features/auth/hooks/use-token.ts
+++ b/src/features/auth/hooks/use-token.ts
@@ -3,7 +3,7 @@ import { persist } from 'zustand/middleware';
 
 interface TokenState {
   token: string | null | undefined;
-  saveToken: (token: string | null) => void;
+  saveToken: (token: string | null | undefined) => void;
 }
 
 const TOKEN_STORAGE_NAME = 'token';

--- a/src/features/client/frames/client-add-frame.tsx
+++ b/src/features/client/frames/client-add-frame.tsx
@@ -1,18 +1,18 @@
 import { FormProvider } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import { Button, FunnelLayout } from '@/features/core';
+import { useRouter } from '@tanstack/react-router';
+
 import { ClientAddForm } from '../components/client-add-form';
 import { useAddClientForm } from '../hooks/use-add-client-form';
 
-import { Button, FunnelLayout } from '@/features/core';
-
-export function ClientAddFrame({
-  onSuccess,
-}: {
-  onSuccess: (client: { clientId: string; clientSecret: string }) => void;
-}) {
+export function ClientAddFrame() {
+  const router = useRouter();
   const { t } = useTranslation();
-  const { form, onSubmit } = useAddClientForm({ onSuccess });
+  const { form, onSubmit } = useAddClientForm({
+    onSuccess: () => router.history.back(),
+  });
 
   return (
     <FormProvider {...form}>

--- a/src/features/core/hooks/use-funnel.ts
+++ b/src/features/core/hooks/use-funnel.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import {
   useLocation,
   useNavigate,
@@ -5,7 +7,6 @@ import {
   useSearch,
 } from '@tanstack/react-router';
 import { AnyFunnelState, createUseFunnel } from '@use-funnel/core';
-import { useMemo } from 'react';
 
 type AnyContext = Record<string, any>;
 type AnyStepContextMap = Record<string, AnyContext>;
@@ -118,7 +119,7 @@ const useFunnelRouter = ({
       go(index: number) {
         router.history.go(index);
       },
-      cleanup() {
+      async cleanup() {
         const currentSearchParams = new URLSearchParams(window.location.search);
         const newLocationState = { ...location.state };
         const id = stepName.split('-')[0]!;
@@ -141,7 +142,7 @@ const useFunnelRouter = ({
           ),
         ]);
 
-        navigate({
+        await navigate({
           replace: true,
           to: `${location.pathname}?${searchParams.toString()}`,
           state: newLocationState,

--- a/src/features/passkey/frames/passkey-add-frame.tsx
+++ b/src/features/passkey/frames/passkey-add-frame.tsx
@@ -1,5 +1,5 @@
 import { useFunnel } from '@/features/core';
-import { useNavigate } from '@tanstack/react-router';
+import { useRouter } from '@tanstack/react-router';
 
 import { CompleteStep } from './passkey-add-steps/complete-step';
 import { RegisterStep } from './passkey-add-steps/register-step';
@@ -10,7 +10,7 @@ export type PasskeySteps = {
 };
 
 export function PasskeyAddFrame() {
-  const navigate = useNavigate({ from: '/passkeys/new' });
+  const router = useRouter();
   const funnel = useFunnel<PasskeySteps>({
     id: 'passkey',
     initial: {
@@ -28,12 +28,7 @@ export function PasskeyAddFrame() {
         <CompleteStep
           onNext={async () => {
             await funnel.history.cleanup();
-            await navigate({
-              to: '/passkeys',
-              replace: true,
-              viewTransition: { types: ['reload'] },
-              search: (prev) => ({ ...prev }),
-            });
+            router.history.back();
           }}
         />
       )}

--- a/src/features/passkey/frames/passkey-add-frame.tsx
+++ b/src/features/passkey/frames/passkey-add-frame.tsx
@@ -22,13 +22,13 @@ export function PasskeyAddFrame() {
   return (
     <funnel.Render
       register={({ history }) => (
-        <RegisterStep onNext={() => history.push('complete')} />
+        <RegisterStep onNext={() => history.replace('complete')} />
       )}
       complete={() => (
         <CompleteStep
           onNext={async () => {
             funnel.history.cleanup();
-            await navigate({ to: '/passkeys' });
+            await navigate({ to: '/passkeys', replace: true });
           }}
         />
       )}

--- a/src/features/passkey/frames/passkey-add-frame.tsx
+++ b/src/features/passkey/frames/passkey-add-frame.tsx
@@ -27,8 +27,13 @@ export function PasskeyAddFrame() {
       complete={() => (
         <CompleteStep
           onNext={async () => {
-            await navigate({ to: '/passkeys', replace: true });
-            funnel.history.cleanup();
+            await funnel.history.cleanup();
+            await navigate({
+              to: '/passkeys',
+              replace: true,
+              viewTransition: { types: ['reload'] },
+              search: (prev) => ({ ...prev }),
+            });
           }}
         />
       )}

--- a/src/features/passkey/frames/passkey-add-frame.tsx
+++ b/src/features/passkey/frames/passkey-add-frame.tsx
@@ -27,8 +27,8 @@ export function PasskeyAddFrame() {
       complete={() => (
         <CompleteStep
           onNext={async () => {
-            funnel.history.cleanup();
             await navigate({ to: '/passkeys', replace: true });
+            funnel.history.cleanup();
           }}
         />
       )}

--- a/src/features/profile/frames/change-password-frame.tsx
+++ b/src/features/profile/frames/change-password-frame.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 import { patchUserPassword } from '@/data/patch-user-password';
 import { useAuth, useToken } from '@/features/auth';
 import { Pretty, RequireKeys, useFunnel } from '@/features/core';
-import { useNavigate } from '@tanstack/react-router';
 
 import { CompleteStep } from './change-password-steps/complete-step';
 import { CurrentPasswordStep } from './change-password-steps/current-password-step';
@@ -26,7 +25,6 @@ export function ChangePasswordFrame() {
   const { user, signOut } = useAuth();
   const { token } = useToken();
   const { t } = useTranslation();
-  const navigate = useNavigate({ from: '/change-password' });
   const funnel = useFunnel<ChangePasswordSteps>({
     id: 'change_password',
     initial: {
@@ -64,9 +62,8 @@ export function ChangePasswordFrame() {
         <CompleteStep
           step={step}
           onNext={async () => {
-            await navigate({ to: '/auth/login', replace: true });
-            funnel.history.cleanup();
-            await signOut();
+            await funnel.history.cleanup();
+            await signOut(false);
           }}
         />
       )}

--- a/src/features/profile/frames/change-password-frame.tsx
+++ b/src/features/profile/frames/change-password-frame.tsx
@@ -64,8 +64,8 @@ export function ChangePasswordFrame() {
         <CompleteStep
           step={step}
           onNext={async () => {
-            funnel.history.cleanup();
             await navigate({ to: '/auth/login', replace: true });
+            funnel.history.cleanup();
             await signOut();
           }}
         />

--- a/src/features/profile/frames/change-password-frame.tsx
+++ b/src/features/profile/frames/change-password-frame.tsx
@@ -56,17 +56,16 @@ export function ChangePasswordFrame() {
         <NewPasswordStep
           step={step}
           context={context}
-          onNext={(data) => history.push('complete', data)}
+          onNext={(data) => history.replace('complete', data)}
           onUndo={() => history.back()}
         />
       )}
-      complete={({ history, step }) => (
+      complete={({ step }) => (
         <CompleteStep
           step={step}
-          onUndo={() => history.back()}
           onNext={async () => {
             funnel.history.cleanup();
-            await navigate({ to: '/auth/login' });
+            await navigate({ to: '/auth/login', replace: true });
             await signOut();
           }}
         />

--- a/src/features/profile/frames/change-password-steps/complete-step.tsx
+++ b/src/features/profile/frames/change-password-steps/complete-step.tsx
@@ -6,11 +6,9 @@ import { Button, FunnelLayout } from '@/features/core';
 
 export function CompleteStep({
   step,
-  onUndo,
   onNext,
 }: {
   step: string;
-  onUndo: () => void;
   onNext: () => void;
 }) {
   const { t } = useTranslation();
@@ -21,10 +19,9 @@ export function CompleteStep({
   return (
     <FunnelLayout
       key={step}
-      onUndo={onUndo}
+      hideUndo
       title={t('change_password.title')}
       stepTitle={t('change_password.steps.complete.title')}
-      hideUndo
       button={
         // signOut이 되면 자동으로 /auth/login으로 이동하도록 라우팅 되어있음
         <Button variant="primary" className="w-full" onClick={onNext}>

--- a/src/features/profile/frames/change-password-steps/current-password-step.tsx
+++ b/src/features/profile/frames/change-password-steps/current-password-step.tsx
@@ -1,9 +1,9 @@
 import { useFormState } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
-import { useCurrentPasswordForm } from '../../hooks/change-password-steps/use-current-password-form';
-
 import { Button, FunnelLayout, Label, PasswordInput } from '@/features/core';
+
+import { useCurrentPasswordForm } from '../../hooks/change-password-steps/use-current-password-form';
 
 export function CurrentPasswordStep({
   step,

--- a/src/features/profile/frames/issue-password-frame.tsx
+++ b/src/features/profile/frames/issue-password-frame.tsx
@@ -36,8 +36,8 @@ export function IssuePasswordFrame() {
       complete={() => (
         <CompleteStep
           onNext={async () => {
-            funnel.history.cleanup();
             await navigate({ to: '/auth/login', replace: true });
+            funnel.history.cleanup();
             await signOut();
           }}
         />

--- a/src/features/profile/frames/issue-password-frame.tsx
+++ b/src/features/profile/frames/issue-password-frame.tsx
@@ -1,5 +1,4 @@
 import { postUserPassword } from '@/data/post-user-password';
-import { useAuth } from '@/features/auth';
 import { Pretty, RequireKeys, useFunnel } from '@/features/core';
 import { useNavigate } from '@tanstack/react-router';
 
@@ -14,8 +13,7 @@ export type IssuePasswordSteps = {
 };
 
 export function IssuePasswordFrame() {
-  const { signOut } = useAuth();
-  const navigate = useNavigate({ from: '/issue-password' });
+  const navigate = useNavigate();
   const funnel = useFunnel<IssuePasswordSteps>({
     id: 'issue_password',
     initial: {
@@ -32,13 +30,16 @@ export function IssuePasswordFrame() {
           onNext={(data) => history.replace('complete', data)}
         />
       )}
-      // TODO: 추후에 history.cleanup 으로 변경하기
       complete={() => (
         <CompleteStep
           onNext={async () => {
-            await navigate({ to: '/auth/login', replace: true });
-            funnel.history.cleanup();
-            await signOut();
+            await funnel.history.cleanup();
+            await navigate({
+              to: '/auth/login',
+              replace: true,
+              viewTransition: { types: ['reload'] },
+              search: (prev) => ({ ...prev }),
+            });
           }}
         />
       )}

--- a/src/features/profile/frames/issue-password-frame.tsx
+++ b/src/features/profile/frames/issue-password-frame.tsx
@@ -29,15 +29,15 @@ export function IssuePasswordFrame() {
       email={({ history, context }) => (
         <EmailStep
           context={context}
-          onNext={(data) => history.push('complete', data)}
+          onNext={(data) => history.replace('complete', data)}
         />
       )}
-      // TODO: 추후에 history.cleanup 으로 변경하기, 현재 코드 오류 발생
+      // TODO: 추후에 history.cleanup 으로 변경하기
       complete={() => (
         <CompleteStep
           onNext={async () => {
             funnel.history.cleanup();
-            await navigate({ to: '/auth/login' });
+            await navigate({ to: '/auth/login', replace: true });
             await signOut();
           }}
         />

--- a/src/features/profile/frames/profile-frame.tsx
+++ b/src/features/profile/frames/profile-frame.tsx
@@ -127,7 +127,10 @@ export function ProfileFrame() {
               {t('profile.menu.developer')}
             </MenuButton>
           </Link>
-          <MenuButton icon={LogoutIcon} onClick={signOut}>
+          <MenuButton
+            icon={LogoutIcon}
+            onClick={async () => await signOut(false)}
+          >
             {t('profile.menu.logout')}
           </MenuButton>
           <Link to="/withdraw">

--- a/src/features/withdraw/frames/steps/confirm-step.tsx
+++ b/src/features/withdraw/frames/steps/confirm-step.tsx
@@ -50,7 +50,12 @@ export function ConfirmStep({
                 {t('withdraw.steps.confirm.sub_button')}
               </Button>
             </Link>
-            <Button variant="warning" disabled={!clients} loading={isLoading}>
+            <Button
+              className="w-full"
+              variant="warning"
+              disabled={!clients}
+              loading={isLoading}
+            >
               {t('withdraw.steps.confirm.button')}
             </Button>
           </div>

--- a/src/features/withdraw/frames/withdraw-frame.tsx
+++ b/src/features/withdraw/frames/withdraw-frame.tsx
@@ -1,9 +1,9 @@
+import { useAuth } from '@/features/auth';
+import { useFunnel } from '@/features/core';
+
 import { ConfirmStep } from './steps/confirm-step';
 import { DoneStep } from './steps/done-step';
 import { PasswordStep } from './steps/password-step';
-
-import { useAuth } from '@/features/auth';
-import { useFunnel } from '@/features/core';
 
 type User = {
   name: string;
@@ -37,7 +37,7 @@ export function WithdrawFrame() {
         <ConfirmStep
           context={context}
           onNext={() =>
-            history.push('done', (prev) => ({
+            history.replace('done', (prev) => ({
               ...prev,
               password: context.password,
             }))

--- a/src/features/withdraw/frames/withdraw-frame.tsx
+++ b/src/features/withdraw/frames/withdraw-frame.tsx
@@ -44,7 +44,14 @@ export function WithdrawFrame() {
           }
         />
       )}
-      done={() => <DoneStep onNext={() => signOut()} />}
+      done={() => (
+        <DoneStep
+          onNext={async () => {
+            funnel.history.cleanup();
+            await signOut();
+          }}
+        />
+      )}
     />
   );
 }

--- a/src/features/withdraw/frames/withdraw-frame.tsx
+++ b/src/features/withdraw/frames/withdraw-frame.tsx
@@ -13,6 +13,7 @@ type User = {
 
 export function WithdrawFrame() {
   const { signOut, user } = useAuth();
+
   if (!user) throw new Error('User not found');
 
   const funnel = useFunnel<{
@@ -47,8 +48,8 @@ export function WithdrawFrame() {
       done={() => (
         <DoneStep
           onNext={async () => {
-            funnel.history.cleanup();
-            await signOut();
+            await funnel.history.cleanup();
+            await signOut(false);
           }}
         />
       )}

--- a/src/index.css
+++ b/src/index.css
@@ -61,19 +61,37 @@
 }
 
 @keyframes ping1 {
-  0%    { transform: scale(1); }
-  50%   { transform: scale(1.5); }
-  100%  { transform: scale(1); }
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.5);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 @keyframes ping2 {
-  0%    { transform: scale(1); }
-  50%   { transform: scale(1.5); }
-  100%  { transform: scale(1); }
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.5);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 @keyframes ping3 {
-  0%    { transform: scale(1); }
-  50%   { transform: scale(1.5); }
-  100%  { transform: scale(1); }
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.5);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 /* View Transition Animations */
@@ -83,43 +101,75 @@
 }
 
 @keyframes slide-out-to-left {
-  from { transform: translateX(0%); }
-  to   { transform: translateX(-100%); }
+  from {
+    transform: translateX(0%);
+  }
+  to {
+    transform: translateX(-100%);
+  }
 }
 @keyframes slide-in-from-right {
-  from { transform: translateX(100%); }
-  to   { transform: translateX(0%); }
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0%);
+  }
 }
 @keyframes slide-out-to-right {
-  from { transform: translateX(0%); }
-  to   { transform: translateX(100%); }
+  from {
+    transform: translateX(0%);
+  }
+  to {
+    transform: translateX(100%);
+  }
 }
 @keyframes slide-in-from-left {
-  from { transform: translateX(-100%); }
-  to   { transform: translateX(0%); }
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0%);
+  }
 }
 
 @keyframes fade-out {
-  from { opacity: 1; }
-  to   { opacity: 0; }
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
 }
 @keyframes fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 @keyframes scale-down {
-  from { transform: scale(1); }
-  to   { transform: scale(0.95); }
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(0.95);
+  }
 }
 @keyframes scale-up {
-  from { transform: scale(0.95); }
-  to   { transform: scale(1); }
+  from {
+    transform: scale(0.95);
+  }
+  to {
+    transform: scale(1);
+  }
 }
 
 :root {
-  --anim-fast: 150ms cubic-bezier(0.4, 0.0, 0.2, 1);
-  --anim-medium: 300ms cubic-bezier(0.4, 0.0, 0.2, 1);
-  --anim-slow:  400ms cubic-bezier(0.4, 0.0, 0.2, 1);
+  --anim-fast: 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  --anim-medium: 300ms cubic-bezier(0.4, 0, 0.2, 1);
+  --anim-slow: 400ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /* forwards */
@@ -145,11 +195,13 @@ html:active-view-transition-type(backwards) {
 /* reload */
 html:active-view-transition-type(reload) {
   &::view-transition-old(root) {
-    animation: fade-out var(--anim-fast) both,
-               scale-down var(--anim-fast) both;
+    animation:
+      fade-out var(--anim-fast) both,
+      scale-down var(--anim-fast) both;
   }
   &::view-transition-new(root) {
-    animation: fade-in var(--anim-fast) both 0.25s,
-               scale-up var(--anim-fast) both 0.25s;
+    animation:
+      fade-in var(--anim-fast) both 0.25s,
+      scale-up var(--anim-fast) both 0.25s;
   }
 }

--- a/src/routes/_auth-required.tsx
+++ b/src/routes/_auth-required.tsx
@@ -1,4 +1,6 @@
-import { useAuth } from '@/features/auth';
+import { useMemo } from 'react';
+
+import { useAuth, useToken } from '@/features/auth';
 import {
   Navigate,
   Outlet,
@@ -22,16 +24,22 @@ const cleanupAllFunnel = (href: string): string => {
 
 const AuthRequiredLayout = () => {
   const { user } = useAuth();
+  const { token } = useToken();
   const router = useRouter();
+
+  const searchParams = useMemo(() => {
+    const shouldRedirect = token === null;
+    return shouldRedirect
+      ? { redirect: cleanupAllFunnel(router.history.location.href) }
+      : {};
+  }, [token, router.history.location.href]);
 
   if (user === undefined) return null;
   if (user === null) {
-    const redirect = cleanupAllFunnel(router.history.location.href);
-
     return (
       <Navigate
         to="/auth/login"
-        search={{ redirect }}
+        search={searchParams}
         replace
         viewTransition={{ types: ['reload'] }}
       />

--- a/src/routes/_auth-required.tsx
+++ b/src/routes/_auth-required.tsx
@@ -1,11 +1,10 @@
+import { useAuth } from '@/features/auth';
 import {
-  createFileRoute,
   Navigate,
   Outlet,
+  createFileRoute,
   useRouter,
 } from '@tanstack/react-router';
-
-import { useAuth } from '@/features/auth';
 
 const cleanupAllFunnel = (href: string): string => {
   const url = new URL(href, window.location.origin);

--- a/src/routes/_auth-required/clients/new.tsx
+++ b/src/routes/_auth-required/clients/new.tsx
@@ -1,14 +1,8 @@
+import { ClientAddFrame } from '@/features/client';
 import { createFileRoute } from '@tanstack/react-router';
 
-import { ClientAddFrame } from '@/features/client';
-
 const ClientAddPage = () => {
-  const navigate = Route.useNavigate();
-  return (
-    <ClientAddFrame
-      onSuccess={() => navigate({ to: '/clients', replace: true })}
-    />
-  );
+  return <ClientAddFrame />;
 };
 
 export const Route = createFileRoute('/_auth-required/clients/new')({


### PR DESCRIPTION
일단 많이 테스트해보긴 했는데, 히스토리가 꼬이는 문제 없이 모든 UX가 물흐르듯이 진행되는지 다른 사람도 테스트해봤으면 좋겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - 인증·프로필·패스키·출금 플로우에서 이동을 push→replace 또는 뒤로가기 기반으로 정리해 뒤로가기 기록과 완료 후 동작을 일관화.
  - 완료 단계에서 히스토리 정리 후 이동하고 쿼리 보존 및 뷰 전환(reload)을 적용해 화면 전환을 매끄럽게 개선.
  - 로그아웃을 비동기 처리해 완료까지 대기하고, 일부 흐름에서 리다이렉트 여부를 제어할 수 있도록 변경.

- Style
  - 출금 확인 버튼을 전체 너비로 확장.
  - CSS 애니메이션 블록 포매팅 정리(시각적 변경 없음).

- Chores
  - 라우터·훅 사용 방식 정리 및 불필요한 의존성 제거.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->