### PR TITLE
fix: add and remove form validation correctly

### DIFF
--- a/src/features/auth/hooks/use-login-form.ts
+++ b/src/features/auth/hooks/use-login-form.ts
@@ -13,7 +13,12 @@ import { useToken } from './use-token';
 
 const createSchema = (t: TFunction) =>
   z.object({
-    email: z.string().email(t('login.inputs.email.errors.format')),
+    email: z
+      .string()
+      .regex(
+        /^\S+@(?:gm\.)?gist\.ac\.kr$/,
+        t('login.inputs.email.errors.format'),
+      ),
     password: z.string().min(1, t('login.inputs.password.errors.format')),
   });
 

--- a/src/features/profile/hooks/change-password-steps/use-current-password-form.ts
+++ b/src/features/profile/hooks/change-password-steps/use-current-password-form.ts
@@ -16,7 +16,7 @@ const createSchema = (t: TFunction) =>
     password: z
       .string()
       .min(
-        12,
+        1,
         t(
           'change_password.steps.current_password.inputs.password.errors.format',
         ),

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -120,7 +120,7 @@
         "label": "GIST Email",
         "placeholder": "m@gm.gist.ac.kr",
         "errors": {
-          "format": "Please enter your email"
+          "format": "Please use a GIST email (@gm.gist.ac.kr, @gist.ac.kr)"
         }
       },
       "password": {

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -120,7 +120,7 @@
         "label": "GIST 이메일",
         "placeholder": "m@gm.gist.ac.kr",
         "errors": {
-          "format": "이메일을 입력해주세요"
+          "format": "지스트 메일(@gm.gist.ac.kr, @gist.ac.kr)을 사용해주세요"
         }
       },
       "password": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 로그인 이메일 검증을 GIST 메일(@gm.gist.ac.kr, @gist.ac.kr)만 허용하도록 개선해 잘못된 도메인 입력을 명확히 차단했습니다.
  - 현재 비밀번호 입력 단계의 최소 길이 제한을 1자로 완화해 일부 계정에서 인증이 불필요하게 막히던 문제를 해소했습니다.
- 작업
  - 로그인 이메일 형식 오류 메시지를 한/영 모두에서 GIST 메일 사용 안내로 업데이트해 안내 문구를 명확화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->