### PR TITLE
fix: infinite loop in authorize

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "account-fe",
   "private": true,
-  "version": "2.6.0",
+  "version": "2.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/oauth/components/authorize-form.tsx
+++ b/src/features/oauth/components/authorize-form.tsx
@@ -61,7 +61,7 @@ export function AuthorizeForm({
   );
 
   useEffect(() => {
-    if (requiredScopeValues.some((v) => !v)) {
+    if (!requiredAllAgree) {
       setError('root', {
         message: t('authorize.errors.required_scopes'),
         type: 'required',
@@ -69,7 +69,7 @@ export function AuthorizeForm({
     } else {
       clearErrors('root');
     }
-  }, [clearErrors, requiredScopeValues, setError, t]);
+  }, [requiredAllAgree, clearErrors, setError, t]);
 
   useEffect(() => {
     requiredScopes.forEach((scope) => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small front-end logic tweak limited to form validation and a version bump; low likelihood of side effects beyond required-scope error display timing.
> 
> **Overview**
> Fixes a potential infinite re-render in `AuthorizeForm` by basing required-scope validation on the memoized `requiredAllAgree` flag and updating the `useEffect` dependency list accordingly.
> 
> Bumps the app version from `2.6.0` to `2.6.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0797511f08523d33ce8c88c64f5d756fda48ffdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 버전을 2.6.0에서 2.6.1로 업데이트했습니다.

* **Bug Fixes**
  * OAuth 인증 폼의 필수 권한 동의 검증 로직을 개선했습니다. 필수 권한이 모두 동의되었을 때만 정상 진행되고, 미동의 시 오류 메시지가 명확하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->