### PR TITLE
fix: set refreshed token on retry request in api middleware

### DIFF
--- a/src/features/core/services/api.ts
+++ b/src/features/core/services/api.ts
@@ -33,9 +33,18 @@ const middleware: Middleware = {
         const refreshRes = await postAuthRefresh();
 
         if (refreshRes.ok) {
-          useToken.getState().saveToken(refreshRes.data.accessToken);
-          auxiliaryRequest.retry = true;
-          return options.fetch(auxiliaryRequest);
+          const newToken = refreshRes.data.accessToken;
+          useToken.getState().saveToken(newToken);
+
+          const newHeaders = new Headers(auxiliaryRequest.headers);
+          newHeaders.set('Authorization', `Bearer ${newToken}`);
+
+          const retryRequest = new Request(auxiliaryRequest, {
+            headers: newHeaders,
+          }) as AuxiliaryRequestInit;
+          retryRequest.retry = true;
+
+          return options.fetch(retryRequest);
         } else {
           if (!auxiliaryRequest.keepToken) {
             useToken.getState().saveToken(null);

--- a/src/features/core/services/api.ts
+++ b/src/features/core/services/api.ts
@@ -43,6 +43,7 @@ const middleware: Middleware = {
             headers: newHeaders,
           }) as AuxiliaryRequestInit;
           retryRequest.retry = true;
+          retryRequest.keepToken = auxiliaryRequest.keepToken;
 
           return options.fetch(retryRequest);
         } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인증 토큰 새로고침 후 요청 재시도 로직을 개선했습니다. 재시도되는 요청에 새로 발급된 Authorization 헤더가 명시적으로 반영되어 인증 관련 오류 복구 신뢰성이 향상되었습니다.
  * 토큰 새로고침 실패 시의 기존 무효화 동작(keepToken 관련)은 변경되지 않았습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->