### PR TITLE
fix: resolve UI bug batch (ACF-167, ACF-174, ACF-176)

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -26,6 +26,7 @@ export default function App() {
 
         return (
           <ErrorFallbackFrame
+            error={error}
             status={status}
             message={err.message}
             description={description}

--- a/src/features/auth/components/register-step-undo-warning-overlay.tsx
+++ b/src/features/auth/components/register-step-undo-warning-overlay.tsx
@@ -16,7 +16,7 @@ export function RegisterStepUndoWarningOverlay({
       isOpen={isOpen}
       close={close}
       defaultCloseValue={false}
-      className="mx-10 w-auto"
+      className="min-w-75 max-w-[calc(100%-5rem)]"
       event="register_undo_warning_dialog"
       closeProperties={(value) => ({ result: value ? 'confirm' : 'cancel' })}
     >

--- a/src/features/client/components/client-delete-overlay.tsx
+++ b/src/features/client/components/client-delete-overlay.tsx
@@ -22,7 +22,7 @@ export function ClientDeleteOverlay({
       isOpen={isOpen}
       close={close}
       defaultCloseValue={false}
-      className="mx-10 min-w-75"
+      className="min-w-75 max-w-[calc(100%-5rem)]"
       event="delete_confirmation"
       openProperties={{ resource: 'client' }}
       closeProperties={(value) => ({

--- a/src/features/client/components/client-kick-overlay.tsx
+++ b/src/features/client/components/client-kick-overlay.tsx
@@ -23,7 +23,7 @@ export function ClientKickOverlay({
       isOpen={isOpen}
       close={close}
       defaultCloseValue={false}
-      className="mx-10 min-w-75"
+      className="min-w-75 max-w-[calc(100%-5rem)]"
       event="kick_confirmation"
       openProperties={{ resource: 'member' }}
       closeProperties={(value) => ({

--- a/src/features/client/components/client-picture-form.tsx
+++ b/src/features/client/components/client-picture-form.tsx
@@ -37,7 +37,7 @@ function ClientPictureOverlay({
       isOpen={isOpen}
       close={(_: boolean) => close()}
       defaultCloseValue={false}
-      className="mx-10 w-auto"
+      className="max-w-[calc(100%-5rem)] min-w-75"
       event="client_picture_delete_dialog"
       closeProperties={(v) => ({ result: v ? 'confirm' : 'cancel' })}
     >

--- a/src/features/client/components/client-urls-form.tsx
+++ b/src/features/client/components/client-urls-form.tsx
@@ -35,7 +35,7 @@ export function ClientUrlsForm({ client }: { client: Client }) {
                 <div className="flex items-center gap-3">
                   <div
                     className={cn(
-                      'text-body-1 flex-1',
+                      'text-body-1 min-w-0 flex-1 truncate',
                       isDeleted
                         ? 'text-basics-secondary-label'
                         : 'text-basics-primary-label',

--- a/src/features/core/components/compound/student-id-verification-dialog.tsx
+++ b/src/features/core/components/compound/student-id-verification-dialog.tsx
@@ -24,7 +24,7 @@ export function StudentIdVerificationDialog({
       isOpen={isOpen}
       close={(_: boolean) => close()}
       defaultCloseValue={defaultCloseValue}
-      className="mx-10 min-w-[300px]"
+      className="min-w-[300px] max-w-[calc(100%-5rem)]"
       event="student_id_dialog"
       closeProperties={(value) => ({ result: value ? 'confirm' : 'cancel' })}
     >

--- a/src/features/core/frames/error-fallback-frame.tsx
+++ b/src/features/core/frames/error-fallback-frame.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { ZodError } from 'zod';
 
 import { Button, FunnelLayout } from '@/features/core';
 
@@ -8,6 +9,7 @@ type ErrorFallbackFrameProps = {
   status?: number;
   message?: string;
   description?: string;
+  error?: unknown;
 };
 
 export function ErrorFallbackFrame({
@@ -15,8 +17,21 @@ export function ErrorFallbackFrame({
   status,
   message,
   description,
+  error,
 }: ErrorFallbackFrameProps) {
   const { t } = useTranslation();
+
+  const resolvedMessage = (() => {
+    if (error instanceof ZodError) {
+      return error.issues
+        .map((issue) => {
+          const path = issue.path.join('.');
+          return path ? `${path}: ${issue.message}` : issue.message;
+        })
+        .join('\n');
+    }
+    return message;
+  })();
 
   const handleRetry = useCallback(() => {
     if (onRetry) {
@@ -37,13 +52,13 @@ export function ErrorFallbackFrame({
         </Button>
       }
     >
-      <div className="flex flex-col items-center gap-3 text-center">
+      <div className="flex flex-col items-center gap-3">
         <div className="text-funnel-steptitle text-6xl font-black">
           {status ?? 'Unknown'}
         </div>
-        {message && (
-          <div className="text-body-2 text-basics-secondary-label whitespace-pre-line">
-            {t('error_fallback.details_label')}: {message}
+        {resolvedMessage && (
+          <div className="text-body-2 text-basics-secondary-label w-full whitespace-pre-line">
+            {t('error_fallback.details_label')}: {resolvedMessage}
           </div>
         )}
       </div>

--- a/src/features/passkey/components/passkey-delete-overlay.tsx
+++ b/src/features/passkey/components/passkey-delete-overlay.tsx
@@ -22,7 +22,7 @@ export function PasskeyDeleteOverlay({
       isOpen={isOpen}
       close={close}
       defaultCloseValue={false}
-      className="mx-10 min-w-75"
+      className="min-w-75 max-w-[calc(100%-5rem)]"
       event="delete_confirmation"
       openProperties={{ resource: 'passkey' }}
       closeProperties={(value) => ({

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -15,6 +15,7 @@ export const router = createRouter({
 
     return (
       <ErrorFallbackFrame
+        error={error}
         message={error.message}
         description={description}
         status={status}

--- a/src/stories/client-urls.stories.tsx
+++ b/src/stories/client-urls.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import TrashBinIcon from '@/assets/icons/solid/trash-bin.svg?react';
+import { IconButton, cn } from '@/features/core';
+
+const SAMPLE_URLS = [
+  'https://very-long-redirect-url.example.com/oauth/callback/production/v2',
+  'https://short.io',
+  'https://another-long-url.example.com/path/to/oauth/callback?query=something',
+];
+
+function UrlList({ urls }: { urls: string[] }) {
+  return (
+    <div className="border-basics-tertiary-label flex flex-col gap-4 rounded-lg border p-4">
+      {urls.map((url, index) => (
+        <div className="flex flex-col gap-3" key={index}>
+          <div className="flex items-center gap-3">
+            <div
+              className={cn(
+                'text-body-1 text-basics-primary-label min-w-0 flex-1 truncate',
+              )}
+            >
+              {url}
+            </div>
+            <IconButton
+              variant="grayText"
+              size="none"
+              icon={<TrashBinIcon />}
+            />
+          </div>
+          {index !== urls.length - 1 && (
+            <div className="bg-funnel-separator h-px w-full" />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const meta = {
+  component: UrlList,
+} satisfies Meta<typeof UrlList>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    urls: SAMPLE_URLS,
+  },
+  render: (args) => (
+    <div className="bg-funnel-background p-6 w-80">
+      <UrlList {...args} />
+    </div>
+  ),
+};

--- a/src/stories/error-fallback.stories.tsx
+++ b/src/stories/error-fallback.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ZodError } from 'zod';
+
+import { ErrorFallbackFrame } from '@/features/core';
+
+const meta = {
+  component: ErrorFallbackFrame,
+} satisfies Meta<typeof ErrorFallbackFrame>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const NotFound: Story = {
+  args: {
+    status: 404,
+    message: 'Not Found',
+  },
+};
+
+export const ServerError: Story = {
+  args: {
+    status: 500,
+    message: '서버 내부 오류가 발생했습니다.\n잠시 후 다시 시도해 주세요.',
+  },
+};
+
+export const Unknown: Story = {
+  args: {
+    message: '알 수 없는 오류가 발생했습니다.',
+  },
+};
+
+const zodError = new ZodError([
+  {
+    code: 'invalid_type',
+    expected: 'string',
+    received: 'undefined',
+    path: ['email'],
+    message: 'Required',
+  },
+  {
+    code: 'too_small',
+    minimum: 8,
+    type: 'string',
+    inclusive: true,
+    exact: false,
+    path: ['password'],
+    message: '8자 이상이어야 합니다.',
+  },
+]);
+
+export const ZodValidationError: Story = {
+  args: {
+    error: zodError,
+  },
+};

--- a/src/stories/overlays.stories.tsx
+++ b/src/stories/overlays.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { OverlayProvider, overlay } from 'overlay-kit';
+
+import { RegisterStepUndoWarningOverlay } from '@/features/auth/components/register-step-undo-warning-overlay';
+import { Button } from '@/features/core';
+
+const meta = {
+  component: Button,
+  decorators: [
+    (Story) => (
+      <OverlayProvider>
+        <Story />
+      </OverlayProvider>
+    ),
+  ],
+} satisfies Meta<typeof Button>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function StoryContainer({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="bg-funnel-background flex min-h-64 items-center justify-center p-10">
+      {children}
+    </div>
+  );
+}
+
+export const RegisterUndoWarning: Story = {
+  args: {
+    variant: 'primary' as const,
+    children: '회원가입 취소 확인 모달 열기',
+  },
+  render: (args) => (
+    <StoryContainer>
+      <Button
+        {...args}
+        onClick={() => {
+          overlay.open(({ isOpen, close }) => (
+            <RegisterStepUndoWarningOverlay
+              isOpen={isOpen}
+              close={(_: boolean) => close()}
+            />
+          ));
+        }}
+      />
+    </StoryContainer>
+  ),
+};


### PR DESCRIPTION
resolve #271, #285, #283

- Remove text-center from error fallback message; add ZodError formatting
- Fix URL list item overflow with truncate
- Fix dialog centering by replacing mx-10 with max-w-[calc(100%-5rem)]
- Add Storybook stories for error-fallback, overlays, client-urls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 오류 페이지에서 유효성 검사 오류의 상세 정보를 명확하게 표시
  * 여러 대화 상자의 반응형 레이아웃 개선으로 화면 크기에 맞게 조정
  * 긴 URL이 화면에서 벗어나지 않도록 자동 잘림 처리 추가

* **기타**
  * 개발 문서를 위한 Storybook 스토리 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->